### PR TITLE
DNS: listen on external ip

### DIFF
--- a/ansible/roles/authoritative_dns/tasks/coredns.service
+++ b/ansible/roles/authoritative_dns/tasks/coredns.service
@@ -11,8 +11,8 @@ Type=simple
 ExecStart=/usr/bin/docker run \
     --mount type=bind,source=/etc/coredns,target=/etc/coredns,readonly \
     -w /etc/coredns \
-    -p 53:53/udp \
-    -p 53:53/tcp \
+    -p {{ ip.internal }}:53:53/udp \
+    -p {{ ip.internal }}:53:53/tcp \
     coredns/coredns:latest \
     -conf /etc/coredns/Corefile
 Restart=always

--- a/ansible/roles/authoritative_dns/tasks/main.yml
+++ b/ansible/roles/authoritative_dns/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy coredns.service
-  ansible.builtin.copy:
+  ansible.builtin.template:
     src: coredns.service
     dest: /etc/systemd/system/coredns.service
     owner: root


### PR DESCRIPTION
DNSを外部向けIPでのみListenする。`systemd-resolved`はlocalhostでのみlistenするのでこれで`node0`でも`systemd-resolved`が使える