### PR TITLE
fix resolvectl

### DIFF
--- a/ansible/roles/ip/files/resolved.conf
+++ b/ansible/roles/ip/files/resolved.conf
@@ -1,0 +1,21 @@
+#  This file is managed by ansible
+
+[Resolve]
+# Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
+# Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+# Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
+# Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNS=1.1.1.1 1.0.0.1
+#FallbackDNS=
+#Domains=
+#DNSSEC=no
+#DNSOverTLS=no
+#MulticastDNS=no
+#LLMNR=no
+#Cache=no-negative
+#CacheFromLocalhost=no
+#DNSStubListener=yes
+#DNSStubListenerExtra=
+#ReadEtcHosts=yes
+#ResolveUnicastSingleLabel=no
+#StaleRetentionSec=0

--- a/ansible/roles/ip/tasks/main.yaml
+++ b/ansible/roles/ip/tasks/main.yaml
@@ -29,6 +29,16 @@
     - Restart systemd-networkd
     - Restart systemd-resolved
 
+- name: Copy systemd-resolved configuration file
+  ansible.builtin.copy:
+    src: resolved.conf
+    dest: /etc/systemd/resolved.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart systemd-resolved
+
 - name: Link systemd-resolved
   ansible.builtin.file:
     path: /etc/resolv.conf

--- a/ansible/roles/ip/templates/10-internal.network
+++ b/ansible/roles/ip/templates/10-internal.network
@@ -3,10 +3,9 @@ MACAddress={{ net.internal.mac }}
 
 [Network]
 Address={{ net.internal.ip }}/{{ net.internal.subnet_size }}
-DNS=1.1.1.1
+DNS=172.16.0.232
+Domains=~.hpcs.cs.tsukuba.ac.jp
 
 [Route]
 Destination=0.0.0.0/0
 Gateway=172.16.255.254
-DNS=172.16.0.232
-Domains=~.hpcs.cs.tsukuba.ac.jp


### PR DESCRIPTION
Per-link DNSを書くのは`[Route]`じゃなくて`[Network]`セクションでした。`resolved.conf`はデフォルトのDNSを設定するため。Per-link DNSが有線なので`hpcs.cs.tsukuba.ac.jp`だけは権威に向く