### PR TITLE
add ksugihara to admin

### DIFF
--- a/ansible/roles/rescue/tasks/main.yml
+++ b/ansible/roles/rescue/tasks/main.yml
@@ -40,6 +40,7 @@
     - onokatio # tmaruyama
     - maetin0324 # rmaeda
     - motorailgun # kourakata
+    - k5342 # ksugihara
 
 - name: Create getty
   ansible.builtin.file:


### PR DESCRIPTION
SS D1の杉原さんに`node0`, `node1`へのアクセス権を付与します。正式なadminではないですが、現学生でありadmin経験者であること、メンテを行うことがあることからこのようにします。