### PR TITLE
LDAPサーバ移行

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -20,6 +20,7 @@
   roles:
     - mount_nfs_home
     - slapd
+    - radius
 
 - name: Configure Authoritative DNS
   hosts: node0.lab.hpcs.cs.tsukuba.ac.jp

--- a/ansible/roles/radius/files/auth.hpcs.cs.tsukuba.ac.jp.conf
+++ b/ansible/roles/radius/files/auth.hpcs.cs.tsukuba.ac.jp.conf
@@ -1,0 +1,14 @@
+# renew_before_expiry = 30 days
+version = 1.11.0
+archive_dir = /etc/letsencrypt/archive/auth.hpcs.cs.tsukuba.ac.jp
+cert = /etc/letsencrypt/live/auth.hpcs.cs.tsukuba.ac.jp/cert.pem
+privkey = /etc/letsencrypt/live/auth.hpcs.cs.tsukuba.ac.jp/privkey.pem
+chain = /etc/letsencrypt/live/auth.hpcs.cs.tsukuba.ac.jp/chain.pem
+fullchain = /etc/letsencrypt/live/auth.hpcs.cs.tsukuba.ac.jp/fullchain.pem
+
+# Options used in the renewal process
+[renewalparams]
+authenticator = standalone
+account = 2ccd3f05cbb2902bf5a2376ce48f7ac2
+manual_public_ip_logging_ok = None
+server = https://acme-v02.api.letsencrypt.org/directory

--- a/ansible/roles/radius/files/mods-available/ldap
+++ b/ansible/roles/radius/files/mods-available/ldap
@@ -10,7 +10,7 @@ ldap {
 	#  certificate, if you're using ldaps.  See OpenLDAP documentation
 	#  for the behavioral semantics of specifying more than one host.
 	#server = "ldap.rrdns.example.org ldap.rrdns.example.org ldap.example.org"
-	server  = "127.0.0.1"
+	server  = "auth.lab.hpcs.cs.tsukuba.ac.jp"
 
 	#  Port to connect on, defaults to 389. Setting this to 636 will enable
 	#  LDAPS if start_tls (see below) is not able to be used.

--- a/ansible/roles/radius/files/radius.sh
+++ b/ansible/roles/radius/files/radius.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl restart radiusd

--- a/ansible/roles/radius/handlers/main.yml
+++ b/ansible/roles/radius/handlers/main.yml
@@ -1,0 +1,13 @@
+- name: Restart certbot
+  ansible.builtin.systemd_service:
+    name: certbot-renew
+    daemon_reload: true
+    enabled: true
+    state: restarted
+
+- name: Restart radius
+  ansible.builtin.systemd_service:
+    name: radius
+    daemon_reload: true
+    enabled: true
+    state: restarted

--- a/ansible/roles/radius/tasks/main.yml
+++ b/ansible/roles/radius/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Install certbot
+  community.general.snap:
+    name: certbot
+    classic: true
+  notify: Restart certbot
+
+- name: Create /etc/letsencrypt dirs
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+  loop:
+    - /etc/letsencrypt
+    - /etc/letsencrypt/renewal
+    - /etc/letsencrypt/renewal-hooks
+    - /etc/letsencrypt/renewal-hooks/deploy
+
+- name: Copy auth.hpcs.cs.tsukuba.ac.jp.conf
+  ansible.builtin.copy:
+    src: auth.hpcs.cs.tsukuba.ac.jp.conf
+    dest: /etc/letsencrypt/renewal/auth.hpcs.cs.tsukuba.ac.jp.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart certbot
+
+- name: Copy radius.sh
+  ansible.builtin.copy:
+    src: radius.sh
+    dest: /etc/letsencrypt/renewal-hooks/deploy/radius.sh
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart certbot
+
+- name: Install radius
+  ansible.builtin.apt:
+    name: freeradius
+  notify: Restart radius
+
+- name: Copy radius config
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/etc/freeradius/3.0/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - mods-available/eap
+    - mods-available/ldap
+    - mods-available/mschap
+    - sites-available/default
+    - sites-available/inner-tunnel
+    - users
+  notify: Restart radius
+
+- name: Enable certbot
+  ansible.builtin.systemd_service:
+    name: snap.certbot.renew
+    daemon_reload: true
+    enabled: true
+    state: started
+
+- name: Enable radius
+  ansible.builtin.systemd_service:
+    name: radius
+    daemon_reload: true
+    enabled: true
+    state: started


### PR DESCRIPTION
node0にLDAPサーバとRADIUSサーバを構築し、移行する。

## TODO

- ドキュメント
- gw側での切り替え作業
- 内部ネットワークでのDNS切り替え
- 直IP指定の修正
  - `fs`: Ansible管理外なので怪しい
  - ansible: 一部IP指定していた気がする
  - `mail`: Ansible管理外なので怪しい
  - `www`: Ansible管理外なので怪しい
  - `phpldapadmin`: 未確認

なお、workに関してはDNS指定なのでそのまま移行出来るはずです。

## 当日作業

1. 外部向けDNS切り替え 
2. certbotでの証明書発行
3. 内部向けDNS切り替え
4. `phpldapadmin`動作確認
5. メール、fs、Wikiの動作確認
6. RADIUS切り替え
7. WiFi再接続確認
8. 旧LDAPシャットダウン
9. 旧RADIUSシャットダウン
10. 動作確認（再度）
11. authサーバシャットダウン